### PR TITLE
fixed "The system cannot find the file specified" error while saving SOM model in fcps example

### DIFF
--- a/examples/fcps/fcps.go
+++ b/examples/fcps/fcps.go
@@ -84,7 +84,7 @@ func parseCliFlags() error {
 }
 
 func saveModel(m *som.Map, format, path string) error {
-	file, err := os.Open(path)
+	file, err := os.Create(path)
 	if err != nil {
 		return err
 	}

--- a/som/display.go
+++ b/som/display.go
@@ -86,7 +86,7 @@ func UMatrixSVG(codebook *mat.Dense, dims []int, uShape, title string, writer io
 		if avgDistance > maxDistance {
 			maxDistance = avgDistance
 		}
-		if avgDistance < maxDistance {
+		if avgDistance < minDistance {
 			minDistance = avgDistance
 		}
 	}


### PR DESCRIPTION
If output file does not exist yet, fcps example could not save trained SOM model.
I fixed this by changing os.Open(path) to os.Create(path)